### PR TITLE
Update object-path to ^0.11.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "fs-capacitor": "^6.2.0",
     "http-errors": "^1.8.0",
     "isobject": "^4.0.0",
-    "object-path": "^0.11.5"
+    "object-path": "^0.11.7"
   },
   "devDependencies": {
     "coverage-node": "^5.0.1",


### PR DESCRIPTION
0.11.6 and 0.11.7 fix [CVE-2021-23434](https://nvd.nist.gov/vuln/detail/CVE-2021-23434)